### PR TITLE
:zap: created topic.html file

### DIFF
--- a/learning_logs/templates/learning_logs/topic.html
+++ b/learning_logs/templates/learning_logs/topic.html
@@ -1,0 +1,19 @@
+{% extends 'learning_logs/base.html' %}
+
+{% block content %}
+
+  <p>Topic: {{ topic.text }}</p>
+
+  <p>Entries:</p>
+  <ul>
+    {% for entry in entries %}
+      <li>
+        <p>{{ entry.date_added|date:'M d, Y H:i' }}</p>
+        <p>{{ entry.text|linebreaks }}</p>
+      </li>
+    {% empty %}
+      <li>There are no entries for this topic yet.</li>
+    {% endfor %}
+  </ul>
+  
+{% endblock content %}

--- a/learning_logs/templates/learning_logs/topics.html
+++ b/learning_logs/templates/learning_logs/topics.html
@@ -6,7 +6,10 @@
 
   <ul>
     {% for topic in topics %}
-      <li>{{ topic.text }}</li>
+      <li>
+        <a href="{% url 'learning_logs:topic' topic.id %}">
+          {{ topic.text }}</a>
+      </li>
     {% empty %}
       <li>No topics have been added yet.</li>
     {% endfor %}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -1,13 +1,16 @@
-"""Defines URL patterns for learning_logs"""
+"""Defines URL patterns for learning_logs."""
 
 from django.urls import path
+
 from . import views
 
 app_name = 'learning_logs'
 urlpatterns = [
-  # Home Page
-  path('', views.index, name='index'),
-  
-  # Page that shows all topics
-  path('topics/', views.topics, name='topics'),
+    # Home page
+    path('', views.index, name='index'),
+    # Page that shows all topics.
+    path('topics/', views.topics, name='topics'),
+    # Detail page for a single topic.
+    path('topics/<int:topic_id>/', views.topic, name='topic'),
+
 ]

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -10,3 +10,10 @@ def topics(request):
   topics = Topic.objects.order_by('date_added')
   context = {'topics': topics}
   return render(request, 'learning_logs/topics.html', context)
+
+def topic(request, topic_id):
+  """Show a single topic and all its entries"""
+  topic = Topic.objects.get(id=topic_id)
+  entries = topic.entry_set.order_by('-date_added')
+  context = {'topic':topic, 'entries': entries}
+  return render(request, 'learning_logs/topic.html', context)


### PR DESCRIPTION
added a Detail page for a single topic
the string 'topics/<int:topic_id>/' 
     the first part of the string tells Django to look for URLs that have the word "topic" after the base URL
     the second part of the string, /<int:topic_id>/  matches an integer between two forward slashes and assigns the integer value to an argument called "topic_id"
in views.py added a topic function to retrieve the topic. 
the minus sign in front of "date_added" sorts the results in reverse order -- Displaying the most recent entries
In the Topic.html file include the context dictionary and start a bullet list to show each entry and loop through them
Each bullet lists two pieces of information: the timestamp and the full text of each entry. 
In Django templates, a vertical line ( | ) represents a template filter that modifies the value in a template variable during the rendering process